### PR TITLE
Support both new and old port format

### DIFF
--- a/response_unmarshal_test.go
+++ b/response_unmarshal_test.go
@@ -1,0 +1,64 @@
+package arukas
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func assertPort(t *testing.T, port *Port, number int32, protocol string) {
+	if port.Protocol != protocol || port.Number != number {
+		t.Errorf("Expected %d/%s but got %d/%s", number, protocol, port.Number, port.Protocol)
+	}
+}
+
+func TestUnmsharlOldPortFormat(t *testing.T) {
+	responseBody := `
+		{
+			"data": {
+				"type": "services",
+				"id": "uuid-1",
+				"attributes": {
+					"image": "my-factorio",
+					"ports": [
+						{"protocol": "tcp", "number": 80},
+						{"protocol": "tcp", "number": 443},
+						{"protocol": "udp", "number": 34197}
+					]
+				}
+			}
+		}
+	`
+
+	service := new(ServiceData)
+	if err := json.Unmarshal([]byte(responseBody), service); err != nil {
+		t.Fatal("Failed to unmarshal old format port:", err)
+	}
+
+	assertPort(t, service.Ports()[0], 80, "tcp")
+	assertPort(t, service.Ports()[1], 443, "tcp")
+	assertPort(t, service.Ports()[2], 34197, "udp")
+}
+
+func TestUnmsharlNewPortFormat(t *testing.T) {
+	responseBody := `
+		{
+			"data": {
+				"type": "services",
+				"id": "uuid-1",
+				"attributes": {
+					"image": "my-factorio",
+					"ports": ["80", "443/tcp", "34197/udp"]
+				}
+			}
+		}
+	`
+
+	service := new(ServiceData)
+	if err := json.Unmarshal([]byte(responseBody), service); err != nil {
+		t.Fatal("Failed to unmarshal old format port:", err)
+	}
+
+	assertPort(t, service.Ports()[0], 80, "tcp")
+	assertPort(t, service.Ports()[1], 443, "tcp")
+	assertPort(t, service.Ports()[2], 34197, "udp")
+}

--- a/response_unmarshal_test.go
+++ b/response_unmarshal_test.go
@@ -11,7 +11,7 @@ func assertPort(t *testing.T, port *Port, number int32, protocol string) {
 	}
 }
 
-func TestUnmsharlOldPortFormat(t *testing.T) {
+func TestUnmarshalOldPortFormat(t *testing.T) {
 	responseBody := `
 		{
 			"data": {
@@ -39,7 +39,7 @@ func TestUnmsharlOldPortFormat(t *testing.T) {
 	assertPort(t, service.Ports()[2], 34197, "udp")
 }
 
-func TestUnmsharlNewPortFormat(t *testing.T) {
+func TestUnmarshalNewPortFormat(t *testing.T) {
 	responseBody := `
 		{
 			"data": {

--- a/service.go
+++ b/service.go
@@ -108,7 +108,7 @@ type ServiceAttr struct {
 	CPUs                     float32          `json:"cups,omitempty"`
 	Memory                   int32            `json:"memory,omitempty"`
 	Environment              []*Env           `json:"environment"`
-	Ports                    []*Port          `json:"ports,omitempty"`
+	Ports                    Ports            `json:"ports,omitempty"`
 	PortMappings             [][]*PortMapping `json:"port-mappings,omitempty"`
 	CreatedAt                *time.Time       `json:"created-at,omitempty"`
 	UpdatedAt                *time.Time       `json:"updated-at,omitempty"`

--- a/types.go
+++ b/types.go
@@ -108,12 +108,11 @@ func (ports *Ports) UnmarshalJSON(data []byte) error {
 	var err error
 	if err = json.Unmarshal(data, op); err != nil {
 		// Attempt parse as new format
-		if err := json.Unmarshal(data, np); err != nil {
+		if err = json.Unmarshal(data, np); err != nil {
 			return err
-		} else {
-			if *ports, err = np.toPorts(); err != nil {
-				return err
-			}
+		}
+		if *ports, err = np.toPorts(); err != nil {
+			return err
 		}
 	} else {
 		if *ports, err = op.toPorts(); err != nil {

--- a/types.go
+++ b/types.go
@@ -1,5 +1,11 @@
 package arukas
 
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
 // LinkID used when creating new app/service
 const LinkID = 1
 
@@ -38,6 +44,83 @@ type Port struct {
 	// Number is port number that container exposes.
 	// Valid value range is [1 - 65535]
 	Number int32 `json:"number"`
+}
+
+// Ports is a slice of Ports. A service can have multiple ports.
+type Ports []*Port
+type oldPortFormat Ports
+type newPortFormat []string
+
+func (pf newPortFormat) toPorts() (Ports, error) {
+	ports := make(Ports, 0)
+	for _, p := range pf {
+		var (
+			parsedPort *Port
+			err        error
+		)
+		if parsedPort, err = parseNewPortFormat(p); err != nil {
+			return nil, err
+		}
+
+		ports = append(ports, parsedPort)
+	}
+
+	return ports, nil
+}
+
+func (pf oldPortFormat) toPorts() (Ports, error) {
+	ports := make(Ports, 0)
+	for _, p := range pf {
+		ports = append(ports,
+			&Port{
+				Protocol: p.Protocol,
+				Number:   p.Number,
+			},
+		)
+	}
+	return ports, nil
+}
+
+func parseNewPortFormat(str string) (*Port, error) {
+	var protocol string
+	var parsedInt int64
+	var number int32
+	var err error
+	splitted := strings.Split(str, "/")
+	if len(splitted) <= 1 {
+		protocol = "tcp"
+	} else {
+		protocol = splitted[1]
+	}
+
+	if parsedInt, err = strconv.ParseInt(splitted[0], 10, 32); err != nil {
+		return nil, err
+	}
+	number = int32(parsedInt)
+
+	return &Port{Protocol: protocol, Number: number}, nil
+}
+
+// UnmarshalJSON parses ports in both old and new port format and convert them to Port.
+func (ports *Ports) UnmarshalJSON(data []byte) error {
+	op := new(oldPortFormat)
+	np := new(newPortFormat)
+	var err error
+	if err = json.Unmarshal(data, op); err != nil {
+		// Attempt parse as new format
+		if err := json.Unmarshal(data, np); err != nil {
+			return err
+		} else {
+			if *ports, err = np.toPorts(); err != nil {
+				return err
+			}
+		}
+	} else {
+		if *ports, err = op.toPorts(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ValidProtocols is a list of valid protocol


### PR DESCRIPTION
Arukas API will change their port format which is the same as Docker
Compose settings.
It will support the old format for a while for requesting - creating
an app with services - but it will always respond with new format.
So supporting both new and old port format, you don't need to be
nervous when to change code.

After Arukas API released the new format, the old format converting
part will be redudant and will be fine to removed.